### PR TITLE
Update draggable for latest React DnD API

### DIFF
--- a/docs/pages/components/table/fragments/draggable.md
+++ b/docs/pages/components/table/fragments/draggable.md
@@ -27,7 +27,8 @@ function DraggableHeaderCell({ children, onDrag, id, ...rest }) {
   });
 
   const [{ isDragging }, drag] = useDrag({
-    item: { id, type: ItemTypes.COLUMN },
+    item: { id },
+    type: ItemTypes.COLUMN,
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),
@@ -67,7 +68,8 @@ function DraggableCell({ children, onDrag, id, rowData, ...rest }) {
   });
 
   const [{ isDragging }, drag] = useDrag({
-    item: { id: rowData.id, type: ItemTypes.ROW },
+    item: { id: rowData.id },
+    type: ItemTypes.ROW,
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),


### PR DESCRIPTION
The API for React DnD was changed in v14 (latest is v15). 
https://github.com/react-dnd/react-dnd/releases/tag/v14.0.0

Current rsuite docs use v10, which causes an error.

Updated codesandbox as well:
https://codesandbox.io/s/rsuite5-table-with-react-dnd-forked-4jcg5v?file=/src/index.js